### PR TITLE
fix hardcoded version tag reported by --version

### DIFF
--- a/cmd/banksyd/config/config.go
+++ b/cmd/banksyd/config/config.go
@@ -42,7 +42,6 @@ func SetupConfig() {
 
 	version.AppName = "banksy"
 	version.Name = "banksyd"
-	version.Version = "v1.0.0"
 }
 
 // SetBech32Prefixes sets the global prefixes to be used when serializing addresses and public keys to Bech32 strings.


### PR DESCRIPTION
This fixes version reported by `--version` call from hardcoded `v1.0.0` to provided via build flags (which is set to current git tag in Makefile https://github.com/notional-labs/composable-testnet/blob/main/Makefile#L7)

`AppName` and `Name`  are kinda useless here as well, as they are provided in Makefile too, but i decided to just fix thing that confuses validators.